### PR TITLE
fix: lit dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 > - [ ] Demo page
 > - [ ] README documentation
 
-A lit-element component for navigating between webpages.
+A Lit component for navigating between webpages.
 
 ## Installation
 

--- a/immersive-nav.js
+++ b/immersive-nav.js
@@ -1,6 +1,6 @@
 import '@brightspace-ui-labs/navigation/d2l-navigation-immersive.js';
 import '@brightspace-ui-labs/navigation/d2l-navigation-link-back.js';
-import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { css, html, LitElement } from 'lit';
 
 class ImmersiveNav extends LitElement {
 	static get properties() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightspace-ui-labs/immersive-nav",
-  "description": "A lit-element component for navigating between webpages.",
+  "description": "A Lit component for navigating between webpages.",
   "type": "module",
   "repository": "https://github.com/BrightspaceUILabs/immersive-nav.git",
   "scripts": {
@@ -46,6 +46,6 @@
   "dependencies": {
     "@brightspace-ui-labs/navigation": "^5",
     "@brightspace-ui/core": "^2",
-    "lit-element": "^3"
+    "lit": "^2"
   }
 }


### PR DESCRIPTION
This isn't a prerequisite for upgrading to Lit 3 next year, but cleaning up the warnings would be nice. Both `lit-element` and `lit-html` have been rolled into `lit` for quite some time.